### PR TITLE
feat/강좌상세 - 모집중, 개설대기중, 마갑API추가, 강

### DIFF
--- a/src/main/java/com/seniorjob/seniorjobserver/controller/LectureController.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/controller/LectureController.java
@@ -13,7 +13,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -63,11 +62,27 @@ public class LectureController {
 		return ResponseEntity.ok(lecture);
 	}
 
-	// GET /api/lectures/search?title={title}
+	// 강좌검색API
+	// 강좌제목
+	// GET http://localhost:8080/api/lectures/search?{title}
+	// 강좌검색API
+	// 강좌제목 + 상태(모집중, 개설대기중, 마감)
+	// GET /api/lectures/search?title={title}&status={status}
 	@GetMapping("/search")
-	public ResponseEntity<List<LectureDto>> searchLecturesByTitle(@RequestParam("title") String title) {
-		List<LectureDto> lectures = lectureService.searchLecturesByTitle(title);
-		return ResponseEntity.ok(lectures);
+	public ResponseEntity<List<LectureDto>> searchLectures(
+			@RequestParam(value = "title", required = false) String title,
+			@RequestParam(value = "status", required = false) LectureEntity.LectureStatus status) {
+		List<LectureDto> lectureList;
+		if (title != null && status != null) {
+			lectureList = lectureService.searchLecturesByTitleAndStatus(title, status);
+		} else if (title != null) {
+			lectureList = lectureService.searchLecturesByTitle(title);
+		} else if (status != null) {
+			lectureList = lectureService.searchLecturesByStatus(status);
+		} else {
+			return ResponseEntity.badRequest().build();
+		}
+		return ResponseEntity.ok(lectureList);
 	}
 
 	// 정렬 api
@@ -103,7 +118,6 @@ public class LectureController {
 
 	// 페이징
 	// GET /api/lectures/paging?page={no}&size={no}
-
 	@GetMapping("/paging")
 	public ResponseEntity<Page<LectureDto>> getLecturesWithPagination(
 			@RequestParam(defaultValue = "0", name = "page") int page,

--- a/src/main/java/com/seniorjob/seniorjobserver/domain/entity/LectureEntity.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/domain/entity/LectureEntity.java
@@ -13,6 +13,13 @@ import java.time.LocalDateTime;
 @Table(name = "lecture")
 public class LectureEntity extends TimeEntity {
 
+    public enum LectureStatus {
+        WAITING,
+        RECRUITING,
+        CLOSED,
+        NORMAL_STATUS
+    }
+
     @Id
     @GeneratedValue(strategy= GenerationType.IDENTITY)
     //@Column(name = "create_id")
@@ -25,7 +32,7 @@ public class LectureEntity extends TimeEntity {
     private Integer maxParticipants;
 
     @Column(name = "current_participants")
-    private Integer currentParticipants;
+    private Integer current_participants; // 수정된 부분
 
     @Column(name = "category")
     private String category;
@@ -60,6 +67,21 @@ public class LectureEntity extends TimeEntity {
     @Column(name = "end_date", columnDefinition = "datetime")
     private LocalDateTime end_date;
 
+    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
+    private LectureStatus status;
+
+    public void updateStatus() {
+        LocalDateTime currentDate = LocalDateTime.now();
+        if (currentDate.isBefore(start_date)) {
+            status = LectureStatus.WAITING;
+        } else if (currentDate.isBefore(end_date)) {
+            status = LectureStatus.RECRUITING;
+        } else {
+            status = LectureStatus.CLOSED;
+        }
+    }
+
     @Column(name = "region")
     private String region;
 
@@ -72,14 +94,14 @@ public class LectureEntity extends TimeEntity {
 
 
     @Builder
-    public LectureEntity(Long create_id, String creator, Integer maxParticipants, Integer currrentParticipants, String category,
+    public LectureEntity(Long create_id, String creator, Integer maxParticipants, Integer current_participants, String category,
                          String bank_name, String account_name, String account_number, Integer price, String title, String content,
                          String cycle, Integer count, LocalDateTime start_date, LocalDateTime end_date, String region, String image_url,
                          LocalDateTime createdDate) {
         this.create_id = create_id;
         this.creator = creator;
         this.maxParticipants = maxParticipants;
-        this.currentParticipants = currrentParticipants;
+        this.current_participants = current_participants;
         this.category = category;
         this.bank_name = bank_name;
         this.account_name = account_name;

--- a/src/main/java/com/seniorjob/seniorjobserver/dto/LectureDto.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/dto/LectureDto.java
@@ -29,6 +29,7 @@ public class LectureDto {
     private LocalDateTime start_date;
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime end_date;
+
     private String region;
     private String image_url;
 
@@ -39,7 +40,7 @@ public class LectureDto {
                 .create_id(create_id)
                 .creator(creator)
                 .maxParticipants(max_participants)
-                .currrentParticipants(current_participants)
+                .current_participants(current_participants)
                 .category(category)
                 .bank_name(bank_name)
                 .account_name(account_name)

--- a/src/main/java/com/seniorjob/seniorjobserver/repository/LectureRepository.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/repository/LectureRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface LectureRepository extends JpaRepository<LectureEntity, Long> {
-    List<LectureEntity> findByTitleContaining(String title);
 
     List<LectureEntity> findAllByOrderByCreatedDateDesc();
 
@@ -23,4 +22,11 @@ public interface LectureRepository extends JpaRepository<LectureEntity, Long> {
     List<LectureEntity> findAllByOrderByPriceAsc();
 
     Page<LectureEntity> findAll(Pageable pageable);
+
+    List<LectureEntity> findByTitleContaining(String title);
+
+    List<LectureEntity> findByTitleContainingAndStatus(String title, LectureEntity.LectureStatus status);
+
+    List<LectureEntity> findByStatus(LectureEntity.LectureStatus status);
+
 }

--- a/src/main/java/com/seniorjob/seniorjobserver/service/LectureService.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/service/LectureService.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -30,6 +31,7 @@ public class LectureService {
 
     public LectureDto createLecture(LectureDto lectureDto) {
         LectureEntity lectureEntity = lectureDto.toEntity();
+        lectureEntity.updateStatus();
         LectureEntity savedLecture = lectureRepository.save(lectureEntity);
         return convertToDto(savedLecture);
     }
@@ -40,7 +42,7 @@ public class LectureService {
 
         existingLecture.setCreator(lectureDto.getCreator());
         existingLecture.setMaxParticipants(lectureDto.getMax_participants());
-        existingLecture.setCurrentParticipants(lectureDto.getCurrent_participants());
+        existingLecture.setCurrent_participants(lectureDto.getCurrent_participants());
         existingLecture.setCategory(lectureDto.getCategory());
         existingLecture.setBank_name(lectureDto.getBank_name());
         existingLecture.setAccount_name(lectureDto.getAccount_name());
@@ -69,13 +71,38 @@ public class LectureService {
         return convertToDto(lectureEntity);
     }
 
-    // 강좌검색
+    // 강좌검색 : 제목
+    // 강좌검색 : 제목+상태
     public List<LectureDto> searchLecturesByTitle(String title) {
         List<LectureEntity> lectureEntities = lectureRepository.findByTitleContaining(title);
         return lectureEntities.stream()
                 .map(this::convertToDto)
                 .collect(Collectors.toList());
     }
+
+    public List<LectureDto> searchLecturesByTitleAndStatus(String title, LectureEntity.LectureStatus status) {
+        if (title != null && status != null) {
+            List<LectureEntity> lectureEntities = lectureRepository.findByTitleContainingAndStatus(title, status);
+            return lectureEntities.stream()
+                    .map(this::convertToDto)
+                    .collect(Collectors.toList());
+        } else if (title != null) {
+            return searchLecturesByTitle(title);
+        } else if (status != null) {
+            return searchLecturesByStatus(status);
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    // 강좌상태
+    public List<LectureDto> searchLecturesByStatus(LectureEntity.LectureStatus status) {
+        List<LectureEntity> lectureEntities = lectureRepository.findByStatus(status);
+        return lectureEntities.stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+    }
+
 
     // 강좌정렬
     // 최신순으로 강좌 정렬 최신 = true 오래된 = false
@@ -118,14 +145,12 @@ public class LectureService {
     }
 
     // 강좌참여API
-
-
     private LectureDto convertToDto(LectureEntity lectureEntity) {
         return LectureDto.builder()
                 .create_id(lectureEntity.getCreate_id())
                 .creator(lectureEntity.getCreator())
                 .max_participants(lectureEntity.getMaxParticipants())
-                .current_participants(lectureEntity.getCurrentParticipants())
+                .current_participants(lectureEntity.getCurrent_participants())
                 .category(lectureEntity.getCategory())
                 .bank_name(lectureEntity.getBank_name())
                 .account_name(lectureEntity.getAccount_name())
@@ -152,7 +177,7 @@ public class LectureService {
                 .create_id(lectureEntity.getCreate_id())
                 .creator(lectureEntity.getCreator())
                 .max_participants(lectureEntity.getMaxParticipants())
-                .current_participants(lectureEntity.getCurrentParticipants())
+                .current_participants(lectureEntity.getCurrent_participants())
                 .category(lectureEntity.getCategory())
                 .bank_name(lectureEntity.getBank_name())
                 .account_name(lectureEntity.getAccount_name())


### PR DESCRIPTION
## **💡 Issue**

(PR | ISSUE) : #{PR | ISSUE 번호} 
강좌상세-모집중,개설대기중,마감API추가 #20

## **⚡ Content**
-   작업한 내용을 적어주세요.
강좌검색API
 강좌제목
 GET http://localhost:8080/api/lectures/search?{title}
 강좌검색API
 강좌제목 + 상태(모집중, 개설대기중, 마감)
 GET /api/lectures/search?title={title}&status={status}

두 API는 searchLectures로 동작하고 Service에서 따로 구현하였습니다.

강좌상태구현
 강좌상태는 lectureEntity에서 enum LectureStatus으로 구현하였고 
 - 강좌 시작날짜 이전일경우 : WAITING
 - 강좌 시작날짜 일경우  : RECRUITING
 - 강좌 시작날짜 지난경우 : CLOSED


## **📆 TBD**


## **🌟 Point**

-   반드시 알아야할 핵심 내용을 적어주세요.
- DB내용을 조금 수정해서 만들었기 때문에 기존에 만들어 두었던 DB내용으로 API를 테스트하는건 안되서
-  기존 데이터를 모두 지우고 새로만들어서 테스트하면 
-  제목으로 검색, 제목 + 상태 검색, 나머지 구현된 API모두 잘 동작합니다.

## ❓ Question

-   강좌 필터링 제목+상태 까지만 만들었는데 코드리뷰하시고 나머지는 수경님이 하실지 말씀해주세요~!
