### PR TITLE
feat/강좌참여API_#9

### DIFF
--- a/src/main/java/com/seniorjob/seniorjobserver/controller/LectureApplyController.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/controller/LectureApplyController.java
@@ -1,0 +1,39 @@
+package com.seniorjob.seniorjobserver.controller;
+
+import com.seniorjob.seniorjobserver.service.LectureApplyService;
+import com.seniorjob.seniorjobserver.service.LectureService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequestMapping("/api/")
+public class LectureApplyController {
+
+    private final LectureApplyService lectureApplyService;
+
+    @Autowired
+    public LectureApplyController(LectureApplyService lectureApplyService) {
+        this.lectureApplyService = lectureApplyService;
+    }
+
+    // 강좌참여API
+    // POST /api/lectureapply/
+    @PostMapping("/lectureapply")
+    public ResponseEntity<String> applyForLecture(@RequestParam Long userId, @RequestParam Long lectureId) {
+        try {
+            lectureApplyService.applyForLecture(userId, lectureId);
+            return ResponseEntity.ok("강좌 신청에 성공하였습니다.");
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+    // 강좌 신청 취소 API
+    @DeleteMapping("/lectureapply")
+    public String cancelLectureApply(@RequestParam Long userId, @RequestParam Long lectureId) {
+        return lectureApplyService.cancelLectureApply(userId, lectureId);
+    }
+}

--- a/src/main/java/com/seniorjob/seniorjobserver/controller/LectureApplyController.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/controller/LectureApplyController.java
@@ -14,7 +14,6 @@ public class LectureApplyController {
 
     private final LectureApplyService lectureApplyService;
 
-    @Autowired
     public LectureApplyController(LectureApplyService lectureApplyService) {
         this.lectureApplyService = lectureApplyService;
     }

--- a/src/main/java/com/seniorjob/seniorjobserver/controller/LectureController.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/controller/LectureController.java
@@ -1,18 +1,13 @@
 package com.seniorjob.seniorjobserver.controller;
 
 import com.seniorjob.seniorjobserver.domain.entity.LectureEntity;
-import com.seniorjob.seniorjobserver.domain.entity.UserEntity;
 import com.seniorjob.seniorjobserver.dto.LectureDto;
-import com.seniorjob.seniorjobserver.dto.UserDto;
 import com.seniorjob.seniorjobserver.service.LectureService;
-import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -84,6 +79,7 @@ public class LectureController {
 		}
 		return ResponseEntity.ok(lectureList);
 	}
+
 
 	// 정렬 api
 	// 최신글정렬 = true, 오래된글정렬 = false

--- a/src/main/java/com/seniorjob/seniorjobserver/domain/entity/LectureApplyEntity.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/domain/entity/LectureApplyEntity.java
@@ -1,0 +1,39 @@
+package com.seniorjob.seniorjobserver.domain.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Setter
+@Entity
+@Table(name = "lectureapply")
+public class LectureApplyEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long leId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "create_id", referencedColumnName = "create_id")
+    private LectureEntity lecture;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "uid", referencedColumnName = "uid")
+    private UserEntity user;
+
+    @Column(name = "created_date", columnDefinition = "datetime DEFAULT CURRENT_TIMESTAMP", nullable = false)
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @Builder
+    public LectureApplyEntity(Long leId, LectureEntity lecture, UserEntity user,
+                              LocalDateTime createdDate) {
+        this.leId = leId;
+        this.lecture = lecture;
+        this.user = user;
+        this.createdDate = createdDate;
+    }
+}

--- a/src/main/java/com/seniorjob/seniorjobserver/domain/entity/LectureEntity.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/domain/entity/LectureEntity.java
@@ -5,8 +5,11 @@ import org.springframework.data.annotation.CreatedDate;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Getter
 @Setter
 @Entity
@@ -22,7 +25,6 @@ public class LectureEntity extends TimeEntity {
 
     @Id
     @GeneratedValue(strategy= GenerationType.IDENTITY)
-    //@Column(name = "create_id")
     private Long create_id;
 
     @Column(name = "creator", nullable = false)

--- a/src/main/java/com/seniorjob/seniorjobserver/domain/entity/UserEntity.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/domain/entity/UserEntity.java
@@ -5,8 +5,11 @@ import lombok.*;
 import javax.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Getter
 @Setter
 @Entity

--- a/src/main/java/com/seniorjob/seniorjobserver/dto/LectureApplyDto.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/dto/LectureApplyDto.java
@@ -1,0 +1,36 @@
+package com.seniorjob.seniorjobserver.dto;
+
+import com.seniorjob.seniorjobserver.domain.entity.LectureApplyEntity;
+import com.seniorjob.seniorjobserver.domain.entity.LectureEntity;
+import com.seniorjob.seniorjobserver.domain.entity.UserEntity;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class LectureApplyDto {
+    private Long leId;
+    private LectureEntity lecture;
+    private UserEntity user;
+    private LocalDateTime createdDate;
+
+    public LectureApplyEntity toEntity() {
+        return LectureApplyEntity.builder()
+                .leId(leId)
+                .lecture(lecture)
+                .user(user)
+                .createdDate(createdDate)
+                .build();
+    }
+
+    @Builder
+    public LectureApplyDto(Long leId, LectureEntity lecture, UserEntity user,
+                           LocalDateTime createdDate) {
+        this.leId = leId;
+        this.lecture = lecture;
+        this.user = user;
+        this.createdDate = createdDate;
+    }
+}

--- a/src/main/java/com/seniorjob/seniorjobserver/repository/LectureApplyRepository.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/repository/LectureApplyRepository.java
@@ -1,0 +1,15 @@
+package com.seniorjob.seniorjobserver.repository;
+
+import com.seniorjob.seniorjobserver.domain.entity.LectureApplyEntity;
+import com.seniorjob.seniorjobserver.domain.entity.LectureEntity;
+import com.seniorjob.seniorjobserver.domain.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LectureApplyRepository extends JpaRepository<LectureApplyEntity, Long> {
+
+    boolean existsByUserAndLecture(UserEntity user, LectureEntity lecture);
+
+    Optional<Object> findByUserAndLecture(UserEntity user, LectureEntity lecture);
+}

--- a/src/main/java/com/seniorjob/seniorjobserver/service/LectureApplyService.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/service/LectureApplyService.java
@@ -1,0 +1,65 @@
+package com.seniorjob.seniorjobserver.service;
+
+import com.seniorjob.seniorjobserver.domain.entity.LectureApplyEntity;
+import com.seniorjob.seniorjobserver.domain.entity.LectureEntity;
+import com.seniorjob.seniorjobserver.domain.entity.UserEntity;
+import com.seniorjob.seniorjobserver.repository.LectureApplyRepository;
+import com.seniorjob.seniorjobserver.repository.LectureRepository;
+import com.seniorjob.seniorjobserver.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+public class LectureApplyService {
+
+    private final LectureRepository lectureRepository;
+    private final LectureApplyRepository lectureApplyRepository;
+    private final UserRepository userRepository;
+
+    @Autowired
+    public LectureApplyService(UserRepository userRepository, LectureRepository lectureRepository, LectureApplyRepository lectureApplyRepository) {
+        this.userRepository = userRepository;
+        this.lectureRepository = lectureRepository;
+        this.lectureApplyRepository = lectureApplyRepository;
+    }
+
+    public void applyForLecture(Long userId, Long lectureId) {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다. id: " + userId));
+
+        LectureEntity lecture = lectureRepository.findById(lectureId)
+                .orElseThrow(() -> new RuntimeException("강좌를 찾을 수 없습니다. id: " + lectureId));
+
+        // 이미 강좌에 참여한 경우 예외 처리
+        if (lectureApplyRepository.existsByUserAndLecture(user, lecture)) {
+            throw new RuntimeException(lectureId + " 이미 참여하신 강좌입니다.");
+        }
+
+        // 강좌 참여 생성
+        LectureApplyEntity lectureApply = LectureApplyEntity.builder()
+                .lecture(lecture)
+                .user(user)
+                .createdDate(LocalDateTime.now())
+                .build();
+
+        lectureApplyRepository.save(lectureApply);
+    }
+
+    public String cancelLectureApply(Long userId, Long lectureId) {
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        LectureEntity lecture = lectureRepository.findById(lectureId)
+                .orElseThrow(() -> new RuntimeException("강좌를 찾을 수 없습니다. id: " + lectureId));
+
+        LectureApplyEntity lectureApply = (LectureApplyEntity) lectureApplyRepository.findByUserAndLecture(user, lecture)
+                .orElseThrow(() -> new RuntimeException("신청된 강좌를 찾을 수 없습니다. userId: " + userId + ", lectureId: " + lectureId));
+
+        lectureApplyRepository.delete(lectureApply);
+
+        return "강좌 신청이 취소되었습니다.";
+    }
+
+}

--- a/src/main/java/com/seniorjob/seniorjobserver/service/LectureService.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/service/LectureService.java
@@ -3,6 +3,7 @@ package com.seniorjob.seniorjobserver.service;
 
 import com.seniorjob.seniorjobserver.domain.entity.LectureEntity;
 import com.seniorjob.seniorjobserver.dto.LectureDto;
+import com.seniorjob.seniorjobserver.dto.UserDto;
 import com.seniorjob.seniorjobserver.repository.LectureRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -79,7 +80,6 @@ public class LectureService {
                 .map(this::convertToDto)
                 .collect(Collectors.toList());
     }
-
     public List<LectureDto> searchLecturesByTitleAndStatus(String title, LectureEntity.LectureStatus status) {
         if (title != null && status != null) {
             List<LectureEntity> lectureEntities = lectureRepository.findByTitleContainingAndStatus(title, status);
@@ -118,7 +118,7 @@ public class LectureService {
                 .collect(Collectors.toList());
     }
 
-    // 인기순 : max_participant가많은순 -> 강좌 참여하기를 만들때 실제참여자가 많은순으로 변경할것임
+        // 인기순 : max_participant가많은순 -> 강좌 참여하기를 만들때 실제참여자가 많은순으로 변경할것임
     public List<LectureDto> getAllLecturesSortByPopularity(boolean descending){
         List<LectureEntity> lectureEntities;
         if(descending){


### PR DESCRIPTION
## **💡 Issue**

(PR | ISSUE) : #{PR | ISSUE 번호} 
feat/강좌참여API_#9

## **⚡ Content**

-   강좌참여API
-   강좌참여신청취소API
-   회원생성API

## **📆 TBD**

-   작업 예정인 태스크를 적어주세요.

강좌인기순 수정 : 현재 강좌최대참여인원수 -> 현재참여인원수로 수정후 : s3 지원가겠습니다.  

## **🌟 Point**

-   반드시 알아야할 핵심 내용을 적어주세요.
- --회원생성---
user테이블
encryption_code = 아직 감이잘안잡혀서..그냥 비밀번호로 때려넣는중이에요..

----강좌참여----
user를 생성하고 create_id(생성된강좌번호)에 uid(생성된 회원번호)가 참여할때 lectureapply테이블에 기록된다.
uid가 없을시 : 사용자를 찾을 수 없습니다. id : uid
createid가 없을시 : 강좌를 찾을 수 없습니다.id : create_id
이미 참가한 강좌일시 : 이미 참여하신 강좌입니다.
한명의 회원이 여러 강좌에 참여가능 

200 강좌신청에 성공하였습니다.

----강좌삭제-----
사용자가 없을경우 : 사용자를 찾을 수 없습니다.
강좌가 없을 경우 : 강좌를 찾을 수 없습니다. id : create_id
신청한 강좌가 없을 경우 : 신청된 강좌가 없습니다.uid, create_id

200 강좌 신청이 취소되었습니다.

## ❓ Question

-   질문 사항이 있을 경우 적어주세요.

API명세는 노션에 기재해두었습니다
강좌정렬 어떻게 하실지 말씀해주세요~!
