### PR TITLE
feat/강좌인기순정렬수정_#24

### DIFF
--- a/src/main/java/com/seniorjob/seniorjobserver/controller/LectureApplyController.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/controller/LectureApplyController.java
@@ -1,12 +1,9 @@
 package com.seniorjob.seniorjobserver.controller;
 
 import com.seniorjob.seniorjobserver.service.LectureApplyService;
-import com.seniorjob.seniorjobserver.service.LectureService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import javax.servlet.http.HttpServletRequest;
 
 @RestController
 @RequestMapping("/api/")
@@ -14,7 +11,6 @@ public class LectureApplyController {
 
     private final LectureApplyService lectureApplyService;
 
-    @Autowired
     public LectureApplyController(LectureApplyService lectureApplyService) {
         this.lectureApplyService = lectureApplyService;
     }

--- a/src/main/java/com/seniorjob/seniorjobserver/domain/entity/LectureEntity.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/domain/entity/LectureEntity.java
@@ -5,8 +5,6 @@ import org.springframework.data.annotation.CreatedDate;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
@@ -21,6 +19,7 @@ public class LectureEntity extends TimeEntity {
         RECRUITING,
         CLOSED,
         NORMAL_STATUS
+        // 신청가능상태, 개설대기상태, 진행상태, 철회상태,
     }
 
     @Id
@@ -34,7 +33,7 @@ public class LectureEntity extends TimeEntity {
     private Integer maxParticipants;
 
     @Column(name = "current_participants")
-    private Integer current_participants; // 수정된 부분
+    private Integer currentParticipants;
 
     @Column(name = "category")
     private String category;
@@ -96,14 +95,14 @@ public class LectureEntity extends TimeEntity {
 
 
     @Builder
-    public LectureEntity(Long create_id, String creator, Integer maxParticipants, Integer current_participants, String category,
+    public LectureEntity(Long create_id, String creator, Integer maxParticipants, Integer currentParticipants, String category,
                          String bank_name, String account_name, String account_number, Integer price, String title, String content,
                          String cycle, Integer count, LocalDateTime start_date, LocalDateTime end_date, String region, String image_url,
                          LocalDateTime createdDate) {
         this.create_id = create_id;
         this.creator = creator;
         this.maxParticipants = maxParticipants;
-        this.current_participants = current_participants;
+        this.currentParticipants = currentParticipants;
         this.category = category;
         this.bank_name = bank_name;
         this.account_name = account_name;
@@ -119,4 +118,18 @@ public class LectureEntity extends TimeEntity {
         this.image_url = image_url;
         this.createdDate = createdDate;
     }
+
+    public void increaseCurrentParticipants() {
+        if (currentParticipants == null) {
+            currentParticipants = 0;
+        }
+        currentParticipants++;
+    }
+    public void decreaseCurrentParticipants() {
+        if (currentParticipants != null && currentParticipants > 0) {
+            currentParticipants--;
+        }
+    }
+
+
 }

--- a/src/main/java/com/seniorjob/seniorjobserver/domain/entity/TimeEntity.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/domain/entity/TimeEntity.java
@@ -1,7 +1,6 @@
 package com.seniorjob.seniorjobserver.domain.entity;
 
 import lombok.Getter;
-import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;

--- a/src/main/java/com/seniorjob/seniorjobserver/domain/entity/UserEntity.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/domain/entity/UserEntity.java
@@ -5,8 +5,6 @@ import lombok.*;
 import javax.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/com/seniorjob/seniorjobserver/dto/LectureDto.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/dto/LectureDto.java
@@ -1,6 +1,7 @@
 package com.seniorjob.seniorjobserver.dto;
 
 import com.seniorjob.seniorjobserver.domain.entity.LectureEntity;
+import com.seniorjob.seniorjobserver.domain.entity.LectureEntity.LectureStatus;
 import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -35,12 +36,22 @@ public class LectureDto {
 
     private LocalDateTime createdDate;
 
+    private LectureEntity.LectureStatus status;
+
+    public LectureEntity.LectureStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(LectureEntity.LectureStatus status) {
+        this.status = status;
+    }
+
     public LectureEntity toEntity() {
         LectureEntity lectureEntity = LectureEntity.builder()
                 .create_id(create_id)
                 .creator(creator)
                 .maxParticipants(max_participants)
-                .current_participants(current_participants)
+                .currentParticipants(current_participants)
                 .category(category)
                 .bank_name(bank_name)
                 .account_name(account_name)
@@ -82,5 +93,28 @@ public class LectureDto {
         this.region = region;
         this.image_url = image_url;
         this.createdDate = createdDate;
+    }
+
+    private LectureDto convertToDto(LectureEntity lectureEntity) {
+        return LectureDto.builder()
+                .create_id(lectureEntity.getCreate_id())
+                .creator(lectureEntity.getCreator())
+                .max_participants(lectureEntity.getMaxParticipants())
+                .current_participants(lectureEntity.getCurrentParticipants())
+                .category(lectureEntity.getCategory())
+                .bank_name(lectureEntity.getBank_name())
+                .account_name(lectureEntity.getAccount_name())
+                .account_number(lectureEntity.getAccount_number())
+                .price(lectureEntity.getPrice())
+                .title(lectureEntity.getTitle())
+                .content(lectureEntity.getContent())
+                .cycle(lectureEntity.getCycle())
+                .count(lectureEntity.getCount())
+                .start_date(lectureEntity.getStart_date())
+                .end_date(lectureEntity.getEnd_date())
+                .region(lectureEntity.getRegion())
+                .image_url(lectureEntity.getImage_url())
+                .createdDate(lectureEntity.getCreatedDate())
+                .build();
     }
 }

--- a/src/main/java/com/seniorjob/seniorjobserver/repository/LectureRepository.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/repository/LectureRepository.java
@@ -4,9 +4,11 @@ import com.seniorjob.seniorjobserver.domain.entity.LectureEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface LectureRepository extends JpaRepository<LectureEntity, Long> {
 
     List<LectureEntity> findAllByOrderByCreatedDateDesc();
@@ -28,5 +30,9 @@ public interface LectureRepository extends JpaRepository<LectureEntity, Long> {
     List<LectureEntity> findByTitleContainingAndStatus(String title, LectureEntity.LectureStatus status);
 
     List<LectureEntity> findByStatus(LectureEntity.LectureStatus status);
+
+    List<LectureEntity> findAllByOrderByCurrentParticipantsAsc();
+
+    List<LectureEntity> findAllByOrderByCurrentParticipantsDesc();
 
 }

--- a/src/main/java/com/seniorjob/seniorjobserver/service/LectureApplyService.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/service/LectureApplyService.java
@@ -43,7 +43,7 @@ public class LectureApplyService {
                 .user(user)
                 .createdDate(LocalDateTime.now())
                 .build();
-
+        lecture.increaseCurrentParticipants();
         lectureApplyRepository.save(lectureApply);
     }
 
@@ -57,6 +57,7 @@ public class LectureApplyService {
         LectureApplyEntity lectureApply = (LectureApplyEntity) lectureApplyRepository.findByUserAndLecture(user, lecture)
                 .orElseThrow(() -> new RuntimeException("신청된 강좌를 찾을 수 없습니다. userId: " + userId + ", lectureId: " + lectureId));
 
+        lecture.decreaseCurrentParticipants();
         lectureApplyRepository.delete(lectureApply);
 
         return "강좌 신청이 취소되었습니다.";

--- a/src/main/java/com/seniorjob/seniorjobserver/service/LectureService.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/service/LectureService.java
@@ -1,18 +1,14 @@
 package com.seniorjob.seniorjobserver.service;
 
-
 import com.seniorjob.seniorjobserver.domain.entity.LectureEntity;
 import com.seniorjob.seniorjobserver.dto.LectureDto;
-import com.seniorjob.seniorjobserver.dto.UserDto;
 import com.seniorjob.seniorjobserver.repository.LectureRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import javax.transaction.Transactional;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -22,7 +18,6 @@ public class LectureService {
     public LectureService(LectureRepository lectureRepository) {
         this.lectureRepository = lectureRepository;
     }
-
     public List<LectureDto> getAllLectures() {
         List<LectureEntity> lectureEntities = lectureRepository.findAll();
         return lectureEntities.stream()
@@ -43,7 +38,7 @@ public class LectureService {
 
         existingLecture.setCreator(lectureDto.getCreator());
         existingLecture.setMaxParticipants(lectureDto.getMax_participants());
-        existingLecture.setCurrent_participants(lectureDto.getCurrent_participants());
+        existingLecture.setCurrentParticipants(lectureDto.getCurrent_participants());
         existingLecture.setCategory(lectureDto.getCategory());
         existingLecture.setBank_name(lectureDto.getBank_name());
         existingLecture.setAccount_name(lectureDto.getAccount_name());
@@ -80,6 +75,7 @@ public class LectureService {
                 .map(this::convertToDto)
                 .collect(Collectors.toList());
     }
+
     public List<LectureDto> searchLecturesByTitleAndStatus(String title, LectureEntity.LectureStatus status) {
         if (title != null && status != null) {
             List<LectureEntity> lectureEntities = lectureRepository.findByTitleContainingAndStatus(title, status);
@@ -103,45 +99,37 @@ public class LectureService {
                 .collect(Collectors.toList());
     }
 
+    // 강좌ID기반 강좌상태 가져오는 메서드
+    public LectureEntity.LectureStatus getLectureStatus(Long create_id) {
+        LectureEntity lectureEntity = lectureRepository.findById(create_id)
+                .orElseThrow(() -> new RuntimeException("강좌아이디 찾지못함 create_id: " + create_id));
+        return lectureEntity.getStatus();
+    }
 
     // 강좌정렬
     // 최신순으로 강좌 정렬 최신 = true 오래된 = false
-    public List<LectureDto> getAllLecturesSortedByCreatedDate(boolean descending) {
-        List<LectureEntity> lectureEntities;
-        if (descending) {
-            lectureEntities = lectureRepository.findAllByOrderByCreatedDateDesc();
-        } else {
-            lectureEntities = lectureRepository.findAllByOrderByCreatedDateAsc();
-        }
-        return lectureEntities.stream()
-                .map(this::convertToDto)
-                .collect(Collectors.toList());
+    public List<LectureDto> sortLecturesByCreatedDate(List<LectureDto> lectureList, boolean descending) {
+        lectureList.sort((a, b) -> descending ?
+                b.getCreatedDate().compareTo(a.getCreatedDate()) :
+                a.getCreatedDate().compareTo(b.getCreatedDate()));
+        return lectureList;
     }
 
-        // 인기순 : max_participant가많은순 -> 강좌 참여하기를 만들때 실제참여자가 많은순으로 변경할것임
-    public List<LectureDto> getAllLecturesSortByPopularity(boolean descending){
-        List<LectureEntity> lectureEntities;
-        if(descending){
-            lectureEntities = lectureRepository.findAllByOrderByMaxParticipantsDesc();
-        }else{
-            lectureEntities = lectureRepository.findAllByOrderByMaxParticipantsAsc();
-        }
-        return lectureEntities.stream()
-                .map(this::convertToDto)
-                .collect(Collectors.toList());
+    // 기존코드 인기순 : max_participant가많은순 -> 강좌 참여하기를 만들때 실제참여자가 많은순으로 변경할것임
+    // 수정된 인기순 : 강좌에 참여한 사람이 많은 강좌순 : 참여자수 current_participants
+    public List<LectureDto> sortLecturesByPopularity(List<LectureDto> lectureList, boolean descending) {
+        lectureList.sort((a, b) -> descending ?
+                b.getCurrent_participants() - a.getCurrent_participants() :
+                a.getCurrent_participants() - b.getCurrent_participants());
+        return lectureList;
     }
 
     // 가격순 : prices(낮은순 높은순)
-    public List<LectureDto> getAllLecturesSortByPrice(boolean descending){
-        List<LectureEntity> lectureEntities;
-        if(descending){
-            lectureEntities = lectureRepository.findAllByOrderByPriceDesc();
-        }else{
-            lectureEntities = lectureRepository.findAllByOrderByPriceAsc();
-        }
-        return lectureEntities.stream()
-                .map(this::convertToDto)
-                .collect(Collectors.toList());
+    public List<LectureDto> sortLecturesByPrice(List<LectureDto> lectureList, boolean descending) {
+        lectureList.sort((a, b) -> descending ?
+                b.getPrice().compareTo(a.getPrice()) :
+                a.getPrice().compareTo(b.getPrice()));
+        return lectureList;
     }
 
     // 강좌참여API
@@ -150,7 +138,7 @@ public class LectureService {
                 .create_id(lectureEntity.getCreate_id())
                 .creator(lectureEntity.getCreator())
                 .max_participants(lectureEntity.getMaxParticipants())
-                .current_participants(lectureEntity.getCurrent_participants())
+                .current_participants(lectureEntity.getCurrentParticipants())
                 .category(lectureEntity.getCategory())
                 .bank_name(lectureEntity.getBank_name())
                 .account_name(lectureEntity.getAccount_name())
@@ -166,39 +154,6 @@ public class LectureService {
                 .image_url(lectureEntity.getImage_url())
                 .createdDate(lectureEntity.getCreatedDate())
                 .build();
-    }
-
-    @Transactional
-    public LectureDto getPost(Long id) {
-        Optional<LectureEntity> lectureEntityWrapper = lectureRepository.findById(id);
-        LectureEntity lectureEntity = lectureEntityWrapper.get();
-
-        LectureDto lectureDTO = LectureDto.builder()
-                .create_id(lectureEntity.getCreate_id())
-                .creator(lectureEntity.getCreator())
-                .max_participants(lectureEntity.getMaxParticipants())
-                .current_participants(lectureEntity.getCurrent_participants())
-                .category(lectureEntity.getCategory())
-                .bank_name(lectureEntity.getBank_name())
-                .account_name(lectureEntity.getAccount_name())
-                .account_number(lectureEntity.getAccount_number())
-                .price(lectureEntity.getPrice())
-                .title(lectureEntity.getTitle())
-                .content(lectureEntity.getContent())
-                .cycle(lectureEntity.getCycle())
-                .count(lectureEntity.getCount())
-                .start_date(lectureEntity.getStart_date())
-                .end_date(lectureEntity.getEnd_date())
-                .region(lectureEntity.getRegion())
-                .image_url(lectureEntity.getImage_url())
-                .createdDate(lectureEntity.getCreatedDate())
-                .build();
-
-        return lectureDTO;
-    }
-    @Transactional
-    public Long savePost(LectureDto lectureDto) {
-        return lectureRepository.save(lectureDto.toEntity()).getCreate_id();
     }
 
     //페이징


### PR DESCRIPTION
## **💡 Issue**

(PR | ISSUE) : #{PR | ISSUE 번호} 
feat/강좌인기순정렬수정_#24

## **⚡ Content**

-   작업한 내용을 적어주세요.
status 데이터 출력
 status데이터 사용가능한 API : LectureAll, LectureDetail, searchLectures

 강좌조건선택필터링API
 searchLectures
 강좌제목, 제목+상태, 제목+상태+최신순/오래된순, 제목+상태+최신순/오래된순 + 인기순/인기낮은순,  제목+상태+최신순/오래된순 + 인기순/인기낮은순 + 가격높은순/낮은순

## **📆 TBD**

-   작업 예정인 태스크를 적어주세요.
-  강좌개설 -> 상태변경할지 정하고 수정작업

## **🌟 Point**

-   반드시 알아야할 핵심 내용을 적어주세요.
-  1. 강좌를 개설한다. -> 2, user회원을 만든다. -> 3. 강좌번호와 회원번호를 입력해서 요청한다.
- -> 4. create_id + uid가 lectureapply 테이블에 저장된다. -> 5. lecture 테이블에 current_participants가 증가한다.
- -> 6. current_participant를 활용하여 인기순위가 결정된다. 

강좌status를 볼수 있는 API는  : 강좌전체목록, 강좌상세내용보기, 강좌조건정렬시, 

## ❓ Question

-   질문 사항이 있을 경우 적어주세요.
 노션 API명세에 상세기록해두었으니 참고부탁드립니다!
모두 참고하시면 기존에 만들어두었던 API는 삭제하겠습니다!
궁금한점있으면 알려주세요~!
