### PR TITLE
Feat/강좌필터링수정 #28

### DIFF
--- a/src/main/java/com/seniorjob/seniorjobserver/service/LectureService.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/service/LectureService.java
@@ -67,33 +67,14 @@ public class LectureService {
         return convertToDto(lectureEntity);
     }
 
-    // 강좌검색 : 제목
-    // 강좌검색 : 제목+상태
-    public List<LectureDto> searchLecturesByTitle(String title) {
-        List<LectureEntity> lectureEntities = lectureRepository.findByTitleContaining(title);
-        return lectureEntities.stream()
-                .map(this::convertToDto)
+    // 강좌필터링API
+    public List<LectureDto> filterLectures(String region, LectureEntity.LectureStatus status, String category) {
+        List<LectureEntity> lectureEntities = lectureRepository.findAll().stream()
+                .filter(lecture -> (region == null || lecture.getRegion().equals(region)) &&
+                        (status == null || lecture.getStatus() == status) &&
+                        (category == null || lecture.getCategory().equals(category)))
                 .collect(Collectors.toList());
-    }
 
-    public List<LectureDto> searchLecturesByTitleAndStatus(String title, LectureEntity.LectureStatus status) {
-        if (title != null && status != null) {
-            List<LectureEntity> lectureEntities = lectureRepository.findByTitleContainingAndStatus(title, status);
-            return lectureEntities.stream()
-                    .map(this::convertToDto)
-                    .collect(Collectors.toList());
-        } else if (title != null) {
-            return searchLecturesByTitle(title);
-        } else if (status != null) {
-            return searchLecturesByStatus(status);
-        } else {
-            return Collections.emptyList();
-        }
-    }
-
-    // 강좌상태
-    public List<LectureDto> searchLecturesByStatus(LectureEntity.LectureStatus status) {
-        List<LectureEntity> lectureEntities = lectureRepository.findByStatus(status);
         return lectureEntities.stream()
                 .map(this::convertToDto)
                 .collect(Collectors.toList());


### PR DESCRIPTION
## **💡 Issue**

(PR | ISSUE) : #{PR | ISSUE 번호} 
Feat/강좌필터링수정 #28

## **⚡ Content**

-   작업한 내용을 적어주세요.
이용자가 지역, 강좌상태, 카테고리를 선택해 원하는 강좌를 찾고싶을때 사용하는 API
노션에 API명세중 강좌필터링(지역, 강좌상태, 카테고리) - 수정 여기에 만들어 두었으니 확인부탁드립니다.

## **📆 TBD**

-   작업 예정인 태스크를 적어주세요.
-  강좌상태수정이 완료되면 강좌필터링수정작업이 조금 필요할것 같습니다.

## **🌟 Point**

-   반드시 알아야할 핵심 내용을 적어주세요.
- GET /api/lectures/filtering?region={region}&status={status}&category={category}
예) 경기 지역에서 현재 모집중인 요리강좌를 찾고 싶다 
/api/lectures/filtering?region=경기&status=RECRUITING&category=요리

LectureService설명
List<LectureEntity> lectureEntities = lectureRepository.findAll().stream()
 - 이전에 만들어준 findAll()메서드를 호출해 결과를 스트림을으로 받아온다. 

.filter(lecture -> (region == null || lecture.getRegion().equals(region)) &&
                        (status == null || lecture.getStatus() == status) &&(category == null || lecture.getCategory().equals(category)))
                .collect(Collectors.toList());
 - 지역, 강좌상태, 카테고리의 조건이 null이라면 해당 조건은 무시되고 조건에 해당한다면 스트림에 보관된다.


LectureController설명
@RequestParam(required = false)
 - URL쿼리 스트링에서 region, status, category파라미터를 가져와 String 형 변수에 할당된다. (require = false)는 null값을 허용한다는 의미

List<LectureDto> filteredLectures = lectureService.filterlectures(region, status, category)
 - LectureService의 fileterLecture메서드를 호출해 필터링 조건에 맞는 강좌를 반환하는 메서드

for (LectureDto lectureDto : filteredLectures) {
			LectureEntity.LectureStatus lectureStatus = lectureService.getLectureStatus(lectureDto.getCreate_id());
			lectureDto.setStatus(lectureStatus);
- 필터링된 강좌목록의 정보를 가져오는 반복문으로 lectureService의 getLectureStatus메서드를 호출해서 반환한다. 

return ResponseEntity.ok(filteredLectures);
- 필터링 결과반환 HTTP상태코드 200 응답

## ❓ Question

-   질문 사항이 있을 경우 적어주세요.
