### PR TITLE
feat/강좌개설API수정_#36

### DIFF
--- a/src/main/java/com/seniorjob/seniorjobserver/controller/LectureController.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/controller/LectureController.java
@@ -94,52 +94,7 @@ public class LectureController {
 		return ResponseEntity.ok(lectureList);
 	}
 
-	// 강좌필터링검색API
-	// 강좌제목
-	// GET http://localhost:8080/api/lectures/search={title}
-	// 강좌제목 + 상태(모집중, 개설대기중, 마감)
-	// GET /api/lectures/search?title={title}&status={status}
-	// 강좌제목 + 상태(모집중, 개설대기중, 마감) + 최신순(false)/오래된순(true)
-	// GET api/lectures/search?title={title}&status={WAITING/RECRUITING/CLOSED}&descending={true/false}
-	// 강좌제목 + 상태(모집중, 개설대기중, 마감) + 최신순(false)/오래된순(true) + 인기순(false)/참여자적은순(true)
-	// GET /api/lectures/search?title={강좌제목}&status={상태}&descending={최신순/오래된순}&sortByPopularity={인기순/참여자적은순}
-	// 강좌제목 + 상태(모집중, 개설대기중, 마감) + 최신순(false)/오래된순(true) + 인기순(false)/참여자적은순(true) + 가격높은순(false)/낮은순(true)
-	// GET /api/lectures/search?title={강좌제목}&status={상태}&descending={최신순/오래된순}&sortByPopularity={인기순/참여자적은순}&sortLecturesByPrice{가격순}
-//	@GetMapping("/search")
-//	public ResponseEntity<List<LectureDto>> searchLectures(
-//			@RequestParam(value = "title", required = false) String title,
-//			@RequestParam(value = "status", required = false) LectureEntity.LectureStatus status,
-//			@RequestParam(value = "sortByPopularity", defaultValue = "false") boolean sortByPopularity,
-//			@RequestParam(value = "descending", defaultValue = "false") boolean descending,
-//			@RequestParam(value = "sortByPrice", defaultValue = "false") boolean sortByPrice,
-//			@RequestParam(value = "priceDescending", defaultValue = "false") boolean priceDescending) {
-//
-//		List<LectureDto> lectureList;
-//		if (title != null && status != null) {
-//			lectureList = lectureService.searchLecturesByTitleAndStatus(title, status);
-//		} else if (title != null) {
-//			lectureList = lectureService.searchLecturesByTitle(title);
-//		} else if (status != null) {
-//			lectureList = lectureService.searchLecturesByStatus(status);
-//		} else {
-//			return ResponseEntity.badRequest().build();
-//		}
-//
-//		for (LectureDto lectureDto : lectureList) {
-//			LectureEntity.LectureStatus lectureStatus = lectureService.getLectureStatus(lectureDto.getCreate_id());
-//			lectureDto.setStatus(lectureStatus);
-//		}
-//
-//		if (sortByPopularity) {
-//			lectureList = lectureService.sortLecturesByPopularity(lectureList, descending);
-//		} else if (sortByPrice) {
-//			lectureList = lectureService.sortLecturesByPrice(lectureList, priceDescending);
-//		} else {
-//			lectureList = lectureService.sortLecturesByCreatedDate(lectureList, descending);
-//		}
-//
-//		return ResponseEntity.ok(lectureList);
-//	}
+
 
 	// 페이징
 	// GET /api/lectures/paging?page={no}&size={no}

--- a/src/main/java/com/seniorjob/seniorjobserver/domain/entity/LectureEntity.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/domain/entity/LectureEntity.java
@@ -93,12 +93,14 @@ public class LectureEntity extends TimeEntity {
     @CreatedDate
     private LocalDateTime createdDate;
 
+    @Column(name = "recruitEnd_date", columnDefinition = "datetime")
+    private LocalDateTime recruitEnd_date;
 
     @Builder
     public LectureEntity(Long create_id, String creator, Integer maxParticipants, Integer currentParticipants, String category,
                          String bank_name, String account_name, String account_number, Integer price, String title, String content,
                          String cycle, Integer count, LocalDateTime start_date, LocalDateTime end_date, String region, String image_url,
-                         LocalDateTime createdDate) {
+                         LocalDateTime createdDate, LocalDateTime recruitEnd_date) {
         this.create_id = create_id;
         this.creator = creator;
         this.maxParticipants = maxParticipants;
@@ -117,6 +119,7 @@ public class LectureEntity extends TimeEntity {
         this.region = region;
         this.image_url = image_url;
         this.createdDate = createdDate;
+        this.recruitEnd_date = recruitEnd_date;
     }
 
     public void increaseCurrentParticipants() {

--- a/src/main/java/com/seniorjob/seniorjobserver/dto/LectureDto.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/dto/LectureDto.java
@@ -30,7 +30,8 @@ public class LectureDto {
     private LocalDateTime start_date;
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime end_date;
-
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
+    private LocalDateTime recruitEnd_date;
     private String region;
     private String image_url;
 
@@ -66,6 +67,7 @@ public class LectureDto {
                 .region(region)
                 .image_url(image_url)
                 .createdDate(createdDate)
+                .recruitEnd_date(recruitEnd_date)
                 .build();
         return lectureEntity;
     }
@@ -74,7 +76,7 @@ public class LectureDto {
     public LectureDto(Long create_id, String creator, Integer max_participants, Integer current_participants, String category,
                       String bank_name, String account_name, String account_number, Integer price, String title, String content,
                       String cycle, Integer count, LocalDateTime start_date, LocalDateTime end_date, String region, String image_url,
-                      LocalDateTime createdDate) {
+                      LocalDateTime createdDate, LocalDateTime recruitEnd_date) {
         this.create_id = create_id;
         this.creator = creator;
         this.max_participants = max_participants;
@@ -93,28 +95,6 @@ public class LectureDto {
         this.region = region;
         this.image_url = image_url;
         this.createdDate = createdDate;
-    }
-
-    private LectureDto convertToDto(LectureEntity lectureEntity) {
-        return LectureDto.builder()
-                .create_id(lectureEntity.getCreate_id())
-                .creator(lectureEntity.getCreator())
-                .max_participants(lectureEntity.getMaxParticipants())
-                .current_participants(lectureEntity.getCurrentParticipants())
-                .category(lectureEntity.getCategory())
-                .bank_name(lectureEntity.getBank_name())
-                .account_name(lectureEntity.getAccount_name())
-                .account_number(lectureEntity.getAccount_number())
-                .price(lectureEntity.getPrice())
-                .title(lectureEntity.getTitle())
-                .content(lectureEntity.getContent())
-                .cycle(lectureEntity.getCycle())
-                .count(lectureEntity.getCount())
-                .start_date(lectureEntity.getStart_date())
-                .end_date(lectureEntity.getEnd_date())
-                .region(lectureEntity.getRegion())
-                .image_url(lectureEntity.getImage_url())
-                .createdDate(lectureEntity.getCreatedDate())
-                .build();
+        this.recruitEnd_date = recruitEnd_date;
     }
 }


### PR DESCRIPTION
## **💡 Issue**

(PR | ISSUE) : #{PR | ISSUE 번호} 
feat/강좌개설API수정_#36

## **⚡ Content**

-   작업한 내용을 적어주세요.
강좌개설시수정 
1. 마감날짜추가recruit_end_date
2. 강좌개설시간 조건설정
3.  모집인원 50명을 초과할 수 없다.

## **📆 TBD**

-   작업 예정인 태스크를 적어주세요.
강좌신청API수정(강좌신청이유)

## **🌟 Point**

-   반드시 알아야할 핵심 내용을 적어주세요.

강좌개설시간조건설정

시작 날짜는 현재 날짜 이후로 설정해야 한다.
종료 날짜는 오늘 이후의 날짜이고 시작 날짜 이후로 설정해야 한다.
강좌 모집 마감 날짜는 시작 날짜 이전으로 설정해야 한다.

1). 강좌 시작 날짜(start_date), 종료 날짜(end_date), 강좌 모집 마감 날짜(recruitEnd_date) 간의 조건
2). 시작 날짜(start_date)는 현재 날짜(LocalDateTime.now()) 이후의 날짜여야 한다. 시작 날짜가 현재 날짜 이전인 경우, 오류를 반환하거나 예외를 발생시킨다.
3). 종료 날짜(end_date)는 오늘 날짜(LocalDateTime.now()) 이후의 날짜이며, 시작 날짜(start_date)보다 이후의 날짜여야 한다. 그렇지 않은 경우, 예외를 발생시킨다.
4). 강좌 모집 마감 날짜(recruitEnd_date)는 시작 날짜(start_date) 이전의 날짜여야 한다. 그렇지 않은 경우, 예외를 발생시킨다.

최대모집인원 50명제한은 프런트에서 제한했지만 서버측 코드도 수정완료

## ❓ Question

-   질문 사항이 있을 경우 적어주세요.
- API에 문제있을시 알려주세요! 그리고 created_date도 문제없이 실행되는지 알려주세요!
- 추가적으로 강좌개설할떄 개선사항이 있으면 알려주세요!
