### PR TITLE
feat/강좌신청API수정_#38

### DIFF
--- a/src/main/java/com/seniorjob/seniorjobserver/controller/LectureApplyController.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/controller/LectureApplyController.java
@@ -1,9 +1,13 @@
 package com.seniorjob.seniorjobserver.controller;
 
+import com.seniorjob.seniorjobserver.domain.entity.LectureApplyEntity;
+import com.seniorjob.seniorjobserver.dto.LectureApplyDto;
 import com.seniorjob.seniorjobserver.service.LectureApplyService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/")
@@ -11,25 +15,34 @@ public class LectureApplyController {
 
     private final LectureApplyService lectureApplyService;
 
+    @Autowired
     public LectureApplyController(LectureApplyService lectureApplyService) {
         this.lectureApplyService = lectureApplyService;
     }
 
-    // 강좌참여API
-    // POST /api/lectureapply/
+    // 강좌 참여 신청 API
+    // POST /api/lectureapply
     @PostMapping("/lectureapply")
-    public ResponseEntity<String> applyForLecture(@RequestParam Long userId, @RequestParam Long lectureId) {
+    public ResponseEntity<String> applyForLecture(@RequestParam Long userId, @RequestParam Long lectureId, @RequestParam(required = false) String applyReason) {
         try {
-            lectureApplyService.applyForLecture(userId, lectureId);
+            lectureApplyService.applyForLecture(userId, lectureId, applyReason);
             return ResponseEntity.ok("강좌 신청에 성공하였습니다.");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
         } catch (RuntimeException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
     }
 
     // 강좌 신청 취소 API
+    // DELETE /api/lectureapply
     @DeleteMapping("/lectureapply")
-    public String cancelLectureApply(@RequestParam Long userId, @RequestParam Long lectureId) {
-        return lectureApplyService.cancelLectureApply(userId, lectureId);
+    public ResponseEntity<String> cancelLectureApply(@RequestParam Long userId, @RequestParam Long lectureId) {
+        try {
+            String message = lectureApplyService.cancelLectureApply(userId, lectureId);
+            return ResponseEntity.ok(message);
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/seniorjob/seniorjobserver/controller/LectureController.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/controller/LectureController.java
@@ -94,52 +94,6 @@ public class LectureController {
 		return ResponseEntity.ok(lectureList);
 	}
 
-	// 강좌필터링검색API
-	// 강좌제목
-	// GET http://localhost:8080/api/lectures/search={title}
-	// 강좌제목 + 상태(모집중, 개설대기중, 마감)
-	// GET /api/lectures/search?title={title}&status={status}
-	// 강좌제목 + 상태(모집중, 개설대기중, 마감) + 최신순(false)/오래된순(true)
-	// GET api/lectures/search?title={title}&status={WAITING/RECRUITING/CLOSED}&descending={true/false}
-	// 강좌제목 + 상태(모집중, 개설대기중, 마감) + 최신순(false)/오래된순(true) + 인기순(false)/참여자적은순(true)
-	// GET /api/lectures/search?title={강좌제목}&status={상태}&descending={최신순/오래된순}&sortByPopularity={인기순/참여자적은순}
-	// 강좌제목 + 상태(모집중, 개설대기중, 마감) + 최신순(false)/오래된순(true) + 인기순(false)/참여자적은순(true) + 가격높은순(false)/낮은순(true)
-	// GET /api/lectures/search?title={강좌제목}&status={상태}&descending={최신순/오래된순}&sortByPopularity={인기순/참여자적은순}&sortLecturesByPrice{가격순}
-//	@GetMapping("/search")
-//	public ResponseEntity<List<LectureDto>> searchLectures(
-//			@RequestParam(value = "title", required = false) String title,
-//			@RequestParam(value = "status", required = false) LectureEntity.LectureStatus status,
-//			@RequestParam(value = "sortByPopularity", defaultValue = "false") boolean sortByPopularity,
-//			@RequestParam(value = "descending", defaultValue = "false") boolean descending,
-//			@RequestParam(value = "sortByPrice", defaultValue = "false") boolean sortByPrice,
-//			@RequestParam(value = "priceDescending", defaultValue = "false") boolean priceDescending) {
-//
-//		List<LectureDto> lectureList;
-//		if (title != null && status != null) {
-//			lectureList = lectureService.searchLecturesByTitleAndStatus(title, status);
-//		} else if (title != null) {
-//			lectureList = lectureService.searchLecturesByTitle(title);
-//		} else if (status != null) {
-//			lectureList = lectureService.searchLecturesByStatus(status);
-//		} else {
-//			return ResponseEntity.badRequest().build();
-//		}
-//
-//		for (LectureDto lectureDto : lectureList) {
-//			LectureEntity.LectureStatus lectureStatus = lectureService.getLectureStatus(lectureDto.getCreate_id());
-//			lectureDto.setStatus(lectureStatus);
-//		}
-//
-//		if (sortByPopularity) {
-//			lectureList = lectureService.sortLecturesByPopularity(lectureList, descending);
-//		} else if (sortByPrice) {
-//			lectureList = lectureService.sortLecturesByPrice(lectureList, priceDescending);
-//		} else {
-//			lectureList = lectureService.sortLecturesByCreatedDate(lectureList, descending);
-//		}
-//
-//		return ResponseEntity.ok(lectureList);
-//	}
 
 	// 페이징
 	// GET /api/lectures/paging?page={no}&size={no}

--- a/src/main/java/com/seniorjob/seniorjobserver/domain/entity/LectureApplyEntity.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/domain/entity/LectureApplyEntity.java
@@ -24,16 +24,20 @@ public class LectureApplyEntity {
     @JoinColumn(name = "uid", referencedColumnName = "uid")
     private UserEntity user;
 
+    @Column(name = "applyReason", nullable = false)
+    private String applyReason;
+
     @Column(name = "created_date", columnDefinition = "datetime DEFAULT CURRENT_TIMESTAMP", nullable = false)
     @CreatedDate
     private LocalDateTime createdDate;
 
     @Builder
-    public LectureApplyEntity(Long leId, LectureEntity lecture, UserEntity user,
+    public LectureApplyEntity(Long leId, LectureEntity lecture, UserEntity user, String applyReason,
                               LocalDateTime createdDate) {
         this.leId = leId;
         this.lecture = lecture;
         this.user = user;
+        this.applyReason = applyReason;
         this.createdDate = createdDate;
     }
 }

--- a/src/main/java/com/seniorjob/seniorjobserver/domain/entity/LectureEntity.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/domain/entity/LectureEntity.java
@@ -93,12 +93,14 @@ public class LectureEntity extends TimeEntity {
     @CreatedDate
     private LocalDateTime createdDate;
 
+    @Column(name = "recruitEnd_date", columnDefinition = "datetime")
+    private LocalDateTime recruitEnd_date;
 
     @Builder
     public LectureEntity(Long create_id, String creator, Integer maxParticipants, Integer currentParticipants, String category,
                          String bank_name, String account_name, String account_number, Integer price, String title, String content,
                          String cycle, Integer count, LocalDateTime start_date, LocalDateTime end_date, String region, String image_url,
-                         LocalDateTime createdDate) {
+                         LocalDateTime createdDate, LocalDateTime recruitEnd_date) {
         this.create_id = create_id;
         this.creator = creator;
         this.maxParticipants = maxParticipants;
@@ -117,6 +119,7 @@ public class LectureEntity extends TimeEntity {
         this.region = region;
         this.image_url = image_url;
         this.createdDate = createdDate;
+        this.recruitEnd_date = recruitEnd_date;
     }
 
     public void increaseCurrentParticipants() {
@@ -130,6 +133,4 @@ public class LectureEntity extends TimeEntity {
             currentParticipants--;
         }
     }
-
-
 }

--- a/src/main/java/com/seniorjob/seniorjobserver/dto/LectureApplyDto.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/dto/LectureApplyDto.java
@@ -14,23 +14,32 @@ public class LectureApplyDto {
     private Long leId;
     private LectureEntity lecture;
     private UserEntity user;
+    private String applyReason;
     private LocalDateTime createdDate;
+
+    public LectureApplyDto(LectureApplyEntity lectureApply) {
+        this.leId = lectureApply.getLeId();
+        this.applyReason = lectureApply.getApplyReason();
+        this.createdDate = lectureApply.getCreatedDate();
+    }
 
     public LectureApplyEntity toEntity() {
         return LectureApplyEntity.builder()
                 .leId(leId)
                 .lecture(lecture)
                 .user(user)
+                .applyReason(applyReason)
                 .createdDate(createdDate)
                 .build();
     }
 
     @Builder
-    public LectureApplyDto(Long leId, LectureEntity lecture, UserEntity user,
+    public LectureApplyDto(Long leId, LectureEntity lecture, UserEntity user, String applyReason,
                            LocalDateTime createdDate) {
         this.leId = leId;
         this.lecture = lecture;
         this.user = user;
+        this.applyReason = applyReason;
         this.createdDate = createdDate;
     }
 }

--- a/src/main/java/com/seniorjob/seniorjobserver/dto/LectureDto.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/dto/LectureDto.java
@@ -30,7 +30,8 @@ public class LectureDto {
     private LocalDateTime start_date;
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime end_date;
-
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
+    private LocalDateTime recruitEnd_date;
     private String region;
     private String image_url;
 
@@ -66,6 +67,7 @@ public class LectureDto {
                 .region(region)
                 .image_url(image_url)
                 .createdDate(createdDate)
+                .recruitEnd_date(recruitEnd_date)
                 .build();
         return lectureEntity;
     }
@@ -74,7 +76,7 @@ public class LectureDto {
     public LectureDto(Long create_id, String creator, Integer max_participants, Integer current_participants, String category,
                       String bank_name, String account_name, String account_number, Integer price, String title, String content,
                       String cycle, Integer count, LocalDateTime start_date, LocalDateTime end_date, String region, String image_url,
-                      LocalDateTime createdDate) {
+                      LocalDateTime createdDate, LocalDateTime recruitEnd_date) {
         this.create_id = create_id;
         this.creator = creator;
         this.max_participants = max_participants;
@@ -93,28 +95,6 @@ public class LectureDto {
         this.region = region;
         this.image_url = image_url;
         this.createdDate = createdDate;
-    }
-
-    private LectureDto convertToDto(LectureEntity lectureEntity) {
-        return LectureDto.builder()
-                .create_id(lectureEntity.getCreate_id())
-                .creator(lectureEntity.getCreator())
-                .max_participants(lectureEntity.getMaxParticipants())
-                .current_participants(lectureEntity.getCurrentParticipants())
-                .category(lectureEntity.getCategory())
-                .bank_name(lectureEntity.getBank_name())
-                .account_name(lectureEntity.getAccount_name())
-                .account_number(lectureEntity.getAccount_number())
-                .price(lectureEntity.getPrice())
-                .title(lectureEntity.getTitle())
-                .content(lectureEntity.getContent())
-                .cycle(lectureEntity.getCycle())
-                .count(lectureEntity.getCount())
-                .start_date(lectureEntity.getStart_date())
-                .end_date(lectureEntity.getEnd_date())
-                .region(lectureEntity.getRegion())
-                .image_url(lectureEntity.getImage_url())
-                .createdDate(lectureEntity.getCreatedDate())
-                .build();
+        this.recruitEnd_date = recruitEnd_date;
     }
 }

--- a/src/main/java/com/seniorjob/seniorjobserver/repository/LectureApplyRepository.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/repository/LectureApplyRepository.java
@@ -5,11 +5,15 @@ import com.seniorjob.seniorjobserver.domain.entity.LectureEntity;
 import com.seniorjob.seniorjobserver.domain.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LectureApplyRepository extends JpaRepository<LectureApplyEntity, Long> {
 
     boolean existsByUserAndLecture(UserEntity user, LectureEntity lecture);
 
-    Optional<Object> findByUserAndLecture(UserEntity user, LectureEntity lecture);
+    Optional<LectureApplyEntity> findByUserAndLecture(UserEntity user, LectureEntity lecture);
+
+    List<LectureApplyEntity> findByUser(UserEntity user);
 }
+

--- a/src/main/java/com/seniorjob/seniorjobserver/service/LectureApplyService.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/service/LectureApplyService.java
@@ -3,13 +3,19 @@ package com.seniorjob.seniorjobserver.service;
 import com.seniorjob.seniorjobserver.domain.entity.LectureApplyEntity;
 import com.seniorjob.seniorjobserver.domain.entity.LectureEntity;
 import com.seniorjob.seniorjobserver.domain.entity.UserEntity;
+import com.seniorjob.seniorjobserver.dto.LectureApplyDto;
 import com.seniorjob.seniorjobserver.repository.LectureApplyRepository;
 import com.seniorjob.seniorjobserver.repository.LectureRepository;
 import com.seniorjob.seniorjobserver.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class LectureApplyService {
@@ -25,7 +31,7 @@ public class LectureApplyService {
         this.lectureApplyRepository = lectureApplyRepository;
     }
 
-    public void applyForLecture(Long userId, Long lectureId) {
+    public void applyForLecture(Long userId, Long lectureId, String applyReason) {
         UserEntity user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다. id: " + userId));
 
@@ -37,16 +43,23 @@ public class LectureApplyService {
             throw new RuntimeException(lectureId + " 이미 참여하신 강좌입니다.");
         }
 
+        // 강좌신청이유 필수! 신청이유가 없을 경우 예외처리
+        if (applyReason == null || applyReason.isEmpty()) {
+            throw new IllegalArgumentException("강좌신청이유를 작성해주세요!!");
+        }
+
         // 강좌 참여 생성
         LectureApplyEntity lectureApply = LectureApplyEntity.builder()
                 .lecture(lecture)
                 .user(user)
                 .createdDate(LocalDateTime.now())
+                .applyReason(applyReason)
                 .build();
         lecture.increaseCurrentParticipants();
         lectureApplyRepository.save(lectureApply);
     }
 
+    // 강좌참여신청취소
     public String cancelLectureApply(Long userId, Long lectureId) {
         UserEntity user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
@@ -62,5 +75,4 @@ public class LectureApplyService {
 
         return "강좌 신청이 취소되었습니다.";
     }
-
 }

--- a/src/main/java/com/seniorjob/seniorjobserver/service/LectureService.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/service/LectureService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -26,6 +27,30 @@ public class LectureService {
     }
 
     public LectureDto createLecture(LectureDto lectureDto) {
+        LocalDateTime currentDate = LocalDateTime.now();
+        LocalDateTime startDate = lectureDto.getStart_date();
+        LocalDateTime endDate = lectureDto.getEnd_date();
+        LocalDateTime recruitEndDate = lectureDto.getRecruitEnd_date();
+
+        // 시작 날짜가 현재 날짜 이전인 경우, 예외
+        if (startDate.isBefore(currentDate)) {
+            throw new IllegalArgumentException("시작 날짜는 현재 날짜 이후로 설정해야 한다.");
+        }
+
+        // 종료 날짜가 오늘 날짜 이후이고 시작 날짜 이후인 경우, 예외
+        if (endDate.isBefore(currentDate) || endDate.isBefore(startDate)) {
+            throw new IllegalArgumentException("종료 날짜는 오늘 이후의 날짜이고 시작 날짜 이후로 설정해야 한다.");
+        }
+
+        // 강좌 모집 마감 날짜가 시작 날짜 이전인 경우, 예외
+        if (recruitEndDate.isAfter(startDate)) {
+            throw new IllegalArgumentException("강좌 모집 마감 날짜는 시작 날짜 이전으로 설정해야 한다.");
+        }
+        // 강좌모집인원은 50명을 초과할수 없다. 초과할경우 예외
+        if (lectureDto.getMax_participants() > 50) {
+            throw new IllegalArgumentException("모집 인원은 50명을 초과할 수 없습니다.");
+        }
+
         LectureEntity lectureEntity = lectureDto.toEntity();
         lectureEntity.updateStatus();
         LectureEntity savedLecture = lectureRepository.save(lectureEntity);
@@ -50,6 +75,7 @@ public class LectureService {
         existingLecture.setCount(lectureDto.getCount());
         existingLecture.setStart_date(lectureDto.getStart_date());
         existingLecture.setEnd_date(lectureDto.getEnd_date());
+        existingLecture.setRecruitEnd_date(lectureDto.getRecruitEnd_date());
         existingLecture.setRegion(lectureDto.getRegion());
         existingLecture.setImage_url(lectureDto.getImage_url());
 
@@ -153,6 +179,7 @@ public class LectureService {
                 .region(lectureEntity.getRegion())
                 .image_url(lectureEntity.getImage_url())
                 .createdDate(lectureEntity.getCreatedDate())
+                .recruitEnd_date(lectureEntity.getRecruitEnd_date())
                 .build();
     }
 


### PR DESCRIPTION
## **💡 Issue**

(PR | ISSUE) : #{PR | ISSUE 번호} 
feat/강좌신청API수정_#38

## **⚡ Content**

-   작업한 내용을 적어주세요.
- 강좌참여신청이유 추가

## **📆 TBD**

-   작업 예정인 태스크를 적어주세요.
- 
- 강좌참여API 이후 수정필요한사항
 회원쪽API만든후 
 회원ID혹은 번호를 받아 회원이 신청한 강좌목록(번호순, 제목, 내용, 카테고리, 내가 신청한 이유 등)을 불러와 강좌신청이유수정과 신청취소를 구현해야한다.

## **🌟 Point**

-   반드시 알아야할 핵심 내용을 적어주세요.
-  강좌참여신청이유추가로 DB에 apply_Reason을 추가하였습니다.
- 강좌신청API명세에 예외처리되는 사항도 올려놨습니다.
- 예외처리 사항 : 강좌신청이유가없울때, 중복신청일때, 해당강좌가없을때

## ❓ Question

-   질문 사항이 있을 경우 적어주세요.
- 신청한강좌목록은 회원쪽 서버를 구현한뒤 수정및 구현작업하겠습니다.
