### PR TITLE
feat/강좌신청-강좌에신청한회원목록조회API_#40

### DIFF
--- a/src/main/java/com/seniorjob/seniorjobserver/controller/LectureApplyController.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/controller/LectureApplyController.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Collections;
 import java.util.List;
 
 @RestController
@@ -43,6 +44,18 @@ public class LectureApplyController {
             return ResponseEntity.ok(message);
         } catch (RuntimeException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+    // 해당 강좌에 신청한 회원 목록 조회 API
+    // GET /api/lectureapply/{lectureId}/applicants
+    @GetMapping("/lectureapply/{lectureId}/applicants")
+    public ResponseEntity<List<LectureApplyDto>> getApplicantsForLecture(@PathVariable Long lectureId) {
+        try {
+            List<LectureApplyDto> applicants = lectureApplyService.getApplicantsForLecture(lectureId);
+            return ResponseEntity.ok(applicants);
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().body(Collections.emptyList());
         }
     }
 }

--- a/src/main/java/com/seniorjob/seniorjobserver/controller/LectureController.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/controller/LectureController.java
@@ -113,6 +113,9 @@ public class LectureController {
 		return ResponseEntity.ok(pagedLectureDto);
 	}
 
+	// 강좌 모집 마감 API
+
+
 
 	private LectureDto convertToDto(LectureEntity lectureEntity) {
 		if (lectureEntity == null)

--- a/src/main/java/com/seniorjob/seniorjobserver/domain/entity/LectureEntity.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/domain/entity/LectureEntity.java
@@ -15,11 +15,27 @@ import java.time.LocalDateTime;
 public class LectureEntity extends TimeEntity {
 
     public enum LectureStatus {
-        WAITING,
-        RECRUITING,
-        CLOSED,
-        NORMAL_STATUS
-        // 신청가능상태, 개설대기상태, 진행상태, 철회상태,
+        AVAILABLE,    // 신청 가능 상태
+        WAITING,      // 개설 대기 상태
+        ONGOING,      // 진행 상태
+        WITHDRAWN,    // 철회 상태
+        COMPLETED     // 완료 상태
+    }
+
+    public void updateStatus() {
+        LocalDateTime now = LocalDateTime.now();
+
+        if (now.isBefore(recruitEnd_date) && currentParticipants < maxParticipants) {
+            status = LectureStatus.AVAILABLE;
+        } else if (now.isBefore(start_date) && (now.isAfter(recruitEnd_date) || currentParticipants.equals(maxParticipants))) {
+            status = LectureStatus.WAITING;
+        } else if (now.isAfter(start_date) && now.isBefore(end_date)) {
+            status = LectureStatus.ONGOING;
+        } else if (now.isAfter(end_date)) {
+            status = LectureStatus.COMPLETED;
+        } else if (now.isAfter(recruitEnd_date) && status.equals(LectureStatus.AVAILABLE)) {
+            status = LectureStatus.WITHDRAWN;
+        }
     }
 
     @Id
@@ -71,17 +87,6 @@ public class LectureEntity extends TimeEntity {
     @Column(name = "status")
     @Enumerated(EnumType.STRING)
     private LectureStatus status;
-
-    public void updateStatus() {
-        LocalDateTime currentDate = LocalDateTime.now();
-        if (currentDate.isBefore(start_date)) {
-            status = LectureStatus.WAITING;
-        } else if (currentDate.isBefore(end_date)) {
-            status = LectureStatus.RECRUITING;
-        } else {
-            status = LectureStatus.CLOSED;
-        }
-    }
 
     @Column(name = "region")
     private String region;

--- a/src/main/java/com/seniorjob/seniorjobserver/dto/LectureApplyDto.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/dto/LectureApplyDto.java
@@ -1,5 +1,6 @@
 package com.seniorjob.seniorjobserver.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.seniorjob.seniorjobserver.domain.entity.LectureApplyEntity;
 import com.seniorjob.seniorjobserver.domain.entity.LectureEntity;
 import com.seniorjob.seniorjobserver.domain.entity.UserEntity;
@@ -11,34 +12,44 @@ import java.time.LocalDateTime;
 @Setter
 @NoArgsConstructor
 public class LectureApplyDto {
+    @JsonIgnore
     private Long leId;
+
+    @JsonIgnore
     private LectureEntity lecture;
+
+    @JsonIgnore
     private UserEntity user;
+
+    private String userName;
     private String applyReason;
+
+    @JsonIgnore
     private LocalDateTime createdDate;
 
     public LectureApplyDto(LectureApplyEntity lectureApply) {
         this.leId = lectureApply.getLeId();
         this.applyReason = lectureApply.getApplyReason();
         this.createdDate = lectureApply.getCreatedDate();
+        this.userName = lectureApply.getUser().getName();
     }
 
+    @JsonIgnore
     public LectureApplyEntity toEntity() {
         return LectureApplyEntity.builder()
                 .leId(leId)
-                .lecture(lecture)
-                .user(user)
                 .applyReason(applyReason)
                 .createdDate(createdDate)
                 .build();
     }
 
     @Builder
-    public LectureApplyDto(Long leId, LectureEntity lecture, UserEntity user, String applyReason,
+    public LectureApplyDto(Long leId, LectureEntity lecture, UserEntity user, String userName, String applyReason,
                            LocalDateTime createdDate) {
         this.leId = leId;
         this.lecture = lecture;
         this.user = user;
+        this.userName = userName;
         this.applyReason = applyReason;
         this.createdDate = createdDate;
     }

--- a/src/main/java/com/seniorjob/seniorjobserver/repository/LectureApplyRepository.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/repository/LectureApplyRepository.java
@@ -14,6 +14,6 @@ public interface LectureApplyRepository extends JpaRepository<LectureApplyEntity
 
     Optional<LectureApplyEntity> findByUserAndLecture(UserEntity user, LectureEntity lecture);
 
-    List<LectureApplyEntity> findByUser(UserEntity user);
+    List<LectureApplyEntity> findByLecture(LectureEntity lecture);
 }
 

--- a/src/main/java/com/seniorjob/seniorjobserver/repository/LectureRepository.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/repository/LectureRepository.java
@@ -11,28 +11,8 @@ import java.util.List;
 @Repository
 public interface LectureRepository extends JpaRepository<LectureEntity, Long> {
 
-    List<LectureEntity> findAllByOrderByCreatedDateDesc();
-
-    List<LectureEntity> findAllByOrderByCreatedDateAsc();
-
-    List<LectureEntity> findAllByOrderByMaxParticipantsDesc();
-
-    List<LectureEntity> findAllByOrderByMaxParticipantsAsc();
-
-    List<LectureEntity> findAllByOrderByPriceDesc();
-
-    List<LectureEntity> findAllByOrderByPriceAsc();
-
-    Page<LectureEntity> findAll(Pageable pageable);
-
     List<LectureEntity> findByTitleContaining(String title);
 
-    List<LectureEntity> findByTitleContainingAndStatus(String title, LectureEntity.LectureStatus status);
-
-    List<LectureEntity> findByStatus(LectureEntity.LectureStatus status);
-
-    List<LectureEntity> findAllByOrderByCurrentParticipantsAsc();
-
-    List<LectureEntity> findAllByOrderByCurrentParticipantsDesc();
+    Page<LectureEntity> findAll(Pageable pageable);
 
 }

--- a/src/main/java/com/seniorjob/seniorjobserver/service/LectureApplyService.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/service/LectureApplyService.java
@@ -75,4 +75,16 @@ public class LectureApplyService {
 
         return "강좌 신청이 취소되었습니다.";
     }
+
+    // 해당 강좌에 신청한 회원 목록 조회 메서드
+    public List<LectureApplyDto> getApplicantsForLecture(Long lectureId) {
+        LectureEntity lecture = lectureRepository.findById(lectureId)
+                .orElseThrow(() -> new RuntimeException("강좌를 찾을 수 없습니다. id: " + lectureId));
+
+        List<LectureApplyEntity> lectureApplies = lectureApplyRepository.findByLecture(lecture);
+        return lectureApplies.stream()
+                .map(LectureApplyDto::new)
+                .collect(Collectors.toList());
+    }
+
 }


### PR DESCRIPTION
## **💡 Issue**

(PR | ISSUE) : #{PR | ISSUE 번호}
feat/강좌신청-강좌에신청한회원목록조회API_#40 

## **⚡ Content**

-   작업한 내용을 적어주세요.
-   코드수정중입니다!
-  강좌상세를 만들때 강좌마감이 꼭 필요해서 강좌신청쪽 구현하고 강좌상세 -> 회원 -> 강좌수정 이렇게 할께요!

## **📆 TBD**

-   작업 예정인 태스크를 적어주세요.
강좌에 신청한 회원 대기,승인,거부API, 강좌 마감API

## **🌟 Point**

-   반드시 알아야할 핵심 내용을 적어주세요.
notion API명세에 올려두겠습니다! 
요청응답은 강좌를 신청한 회원 이름과 강좌신청이유 불러옵니다!

## ❓ Question

-   질문 사항이 있을 경우 적어주세요.
