### PR TITLE
feat/강좌신청API수정_#45

### DIFF
--- a/src/main/java/com/seniorjob/seniorjobserver/controller/LectureApplyController.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/controller/LectureApplyController.java
@@ -50,12 +50,32 @@ public class LectureApplyController {
     // 해당 강좌에 신청한 회원 목록 조회 API
     // GET /api/lectureapply/{lectureId}/applicants
     @GetMapping("/lectureapply/{lectureId}/applicants")
-    public ResponseEntity<List<LectureApplyDto>> getApplicantsForLecture(@PathVariable Long lectureId) {
+    public ResponseEntity<List<LectureApplyDto>> getApplicantsByLectureId(@PathVariable Long lectureId) {
+        List<LectureApplyDto> applicants = lectureApplyService.getApplicantsByLectureId(lectureId);
+        return ResponseEntity.ok(applicants);
+    }
+
+    // 회원목록에서 승인이 된 회원들을 일괄 모집마감하는 API
+    // PUT /api/lectureapply/{lectureId}/close
+    @PutMapping("/lectureapply/{lectureId}/close")
+    public ResponseEntity<String> closeLectureApply(@PathVariable Long lectureId) {
         try {
-            List<LectureApplyDto> applicants = lectureApplyService.getApplicantsForLecture(lectureId);
-            return ResponseEntity.ok(applicants);
+            return lectureApplyService.closeLectureApply(lectureId);
         } catch (RuntimeException e) {
-            return ResponseEntity.badRequest().body(Collections.emptyList());
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+    // 강좌참여신청 승인 상태 개별 변경 API
+    // PUT /api/lectureapply/{userId}/status{lectureId}
+    @PutMapping("/lectureapply/{userId}/status/{lectureId}")
+    public ResponseEntity<String> updateLectureApplyStatus(@PathVariable Long userId, @PathVariable Long lectureId, @RequestParam LectureApplyEntity.LectureApplyStatus status) {
+        try {
+            lectureApplyService.updateLectureApplyStatus(userId, lectureId, status);
+            String message = String.format("강좌참여신청을 변경하였습니다. userId: %d, lectureId: %d", userId, lectureId);
+            return ResponseEntity.ok(message);
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
         }
     }
 }

--- a/src/main/java/com/seniorjob/seniorjobserver/domain/entity/LectureApplyEntity.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/domain/entity/LectureApplyEntity.java
@@ -24,8 +24,29 @@ public class LectureApplyEntity {
     @JoinColumn(name = "uid", referencedColumnName = "uid")
     private UserEntity user;
 
-    @Column(name = "applyReason", nullable = false)
+    @Column(name = "applyReason")
     private String applyReason;
+
+    @Column(name = "recruitment_closed")
+    private Boolean recruitmentClosed;
+
+
+    public enum LectureApplyStatus {
+        승인,
+        대기
+    }
+
+    @Column(name = "lectureapply_status")
+    @Enumerated(EnumType.STRING)
+    private LectureApplyStatus lectureApplyStatus = LectureApplyStatus.승인;
+
+    public LectureApplyStatus getLectureApplyStatus(){
+        return lectureApplyStatus;
+    }
+
+    public void setLectureApplyStatus(LectureApplyStatus lectureApplyStatus){
+        this.lectureApplyStatus = lectureApplyStatus;
+    }
 
     @Column(name = "created_date", columnDefinition = "datetime DEFAULT CURRENT_TIMESTAMP", nullable = false)
     @CreatedDate

--- a/src/main/java/com/seniorjob/seniorjobserver/dto/LectureApplyDto.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/dto/LectureApplyDto.java
@@ -23,18 +23,21 @@ public class LectureApplyDto {
 
     private String userName;
     private String applyReason;
+    private LectureApplyEntity.LectureApplyStatus lectureApplyStatus;
 
     @JsonIgnore
     private LocalDateTime createdDate;
+
+    private Boolean recruitmentClosed;
 
     public LectureApplyDto(LectureApplyEntity lectureApply) {
         this.leId = lectureApply.getLeId();
         this.applyReason = lectureApply.getApplyReason();
         this.createdDate = lectureApply.getCreatedDate();
         this.userName = lectureApply.getUser().getName();
+        this.lectureApplyStatus = lectureApply.getLectureApplyStatus();
     }
 
-    @JsonIgnore
     public LectureApplyEntity toEntity() {
         return LectureApplyEntity.builder()
                 .leId(leId)
@@ -45,12 +48,13 @@ public class LectureApplyDto {
 
     @Builder
     public LectureApplyDto(Long leId, LectureEntity lecture, UserEntity user, String userName, String applyReason,
-                           LocalDateTime createdDate) {
+                           LocalDateTime createdDate, LectureApplyEntity.LectureApplyStatus lectureApplyStatus) {
         this.leId = leId;
         this.lecture = lecture;
         this.user = user;
         this.userName = userName;
         this.applyReason = applyReason;
         this.createdDate = createdDate;
+        this.lectureApplyStatus = lectureApplyStatus;
     }
 }

--- a/src/main/java/com/seniorjob/seniorjobserver/repository/LectureApplyRepository.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/repository/LectureApplyRepository.java
@@ -4,6 +4,7 @@ import com.seniorjob.seniorjobserver.domain.entity.LectureApplyEntity;
 import com.seniorjob.seniorjobserver.domain.entity.LectureEntity;
 import com.seniorjob.seniorjobserver.domain.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,5 +16,9 @@ public interface LectureApplyRepository extends JpaRepository<LectureApplyEntity
     Optional<LectureApplyEntity> findByUserAndLecture(UserEntity user, LectureEntity lecture);
 
     List<LectureApplyEntity> findByLecture(LectureEntity lecture);
+
+    List<LectureApplyEntity> findByLectureAndLectureApplyStatus(LectureEntity lecture, LectureApplyEntity.LectureApplyStatus status);
+
+    Optional<Object> findByLectureAndRecruitmentClosed(LectureEntity lecture, boolean b);
 }
 


### PR DESCRIPTION
## **💡 Issue**

(PR | ISSUE) : #{PR | ISSUE 번호} 
feat/강좌신청API수정_#45

## **⚡ Content**

-   작업한 내용을 적어주세요.
- 강좌신청 수정사항 
-> lectureapply테이블 수정 : lectureapply_status는 대기, 승인 두개이고 디폴트 값은 승인
!! 에러가 생긴다면 기존 테이블의 정보와 달라서 에러가 발생할 수 있기 때문에 새로운 데이터를 만들고 테스트해주세요!!

 1) 신청이유null값 허용 : 아무값도 입력하지 않고 신청시 null로 전송된다.

강좌신청API추가항목
 1) 해당 강좌에 신청한 회원 목록 조회API 추가
 2) 회원목록에서 승인이 된 회원들을 일괄 모집마감하는 api 추가
 : 모집마감버튼을 누르면 해당강좌와 해당강좌에 신청한 회원들중lectureapply테이블의 lectureapply_status가 승인이 되어있는 회원만 recruitClosed컬럼이 활성화된다. (승인되지 않은 회원들의 자동삭제는 일부로 추가하지 않았으므로 강좌진행중에도 대기인 인원들을 확인할 수 있다.) 추가적으로 모집마감이 된 강좌에는 강좌신청이 불가능하다.
 3) 강좌신청상태변경API
 강좌참여신청을 하게되면 디폴트로 "승인"이 되어있다. 
 강좌개설자는 해당강좌에 참여신청한 회원의 강좌신청상태를 개별로 수정할 수 있다.


## **📆 TBD**

-   작업 예정인 태스크를 적어주세요.
- -> 회원파트이후 특정 사용자가 신청한 강좌목록조회(신청강좌, 상태 등)
- db 컬럼네이밍 수정 = 카멜 케이스, 스네이크 케이스 이름 획일화
-  강좌상태API수정 (저장되는 값은 모두 국문으로)

## **🌟 Point**

-   반드시 알아야할 핵심 내용을 적어주세요.
- 테스트시 안되는게 있으면 테이블 정보가 변경되서 그래요!
- 강좌, 유저 새로 만들고 하면 잘될겁니다!

## ❓ Question

-   질문 사항이 있을 경우 적어주세요.
