### PR TITLE
feat/강좌파트세션적용_#73

### DIFF
--- a/src/main/java/com/seniorjob/seniorjobserver/config/SecurityConfiguration.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/config/SecurityConfiguration.java
@@ -24,19 +24,16 @@ import java.io.PrintWriter;
 @Configuration
 @EnableWebSecurity
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
-
     @Autowired
     private UserDetailsService userDetailsService;
-
     @Autowired
     private UserRepository userRepository;
-
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
                 .authorizeRequests()
-                .antMatchers("/api/users/join", "/api/users/all", "/api/lectureapply/apply", "/api/lectureapply/close", "/api/users/login", "/api/users/detail").permitAll()
-                .antMatchers( "/api/users/update", "/api/lectures", "/api/lectures/**").authenticated()
+                .antMatchers("/api/users/join", "/api/users/all", "/api/users/login", "/api/lectures/all", "/api/lectures/detail/**", "/api/lectures/search", "/api/lectures/sort/**", "/api/lectures/paging", "/api/lectureapply/list").permitAll()
+                .antMatchers( "/api/users/update", "/api/lectures", "/api/lectures/**", "/api/lectureapply/apply/**", "/api/lectureapply/close", "/api/lectures/myLectureAll", "api/lectures/myLectureDetail/**", "aip/lectureapply/cancel/**", "/api/lectureapply/close", "/api/lectureapply/approve").authenticated()
                 .anyRequest().authenticated()
                 .and()
                 .httpBasic()

--- a/src/main/java/com/seniorjob/seniorjobserver/config/StorageConfig.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/config/StorageConfig.java
@@ -23,8 +23,5 @@ public class StorageConfig {
         return AmazonS3ClientBuilder.standard()
                 .withCredentials(new AWSStaticCredentialsProvider(credentials))
                 .withRegion(region).build();
-
-
     }
-
 }

--- a/src/main/java/com/seniorjob/seniorjobserver/controller/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/controller/CustomAccessDeniedHandler.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
-
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException, ServletException {

--- a/src/main/java/com/seniorjob/seniorjobserver/controller/LectureApplyController.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/controller/LectureApplyController.java
@@ -1,53 +1,88 @@
 package com.seniorjob.seniorjobserver.controller;
 
 import com.seniorjob.seniorjobserver.domain.entity.LectureApplyEntity;
+import com.seniorjob.seniorjobserver.domain.entity.LectureEntity;
+import com.seniorjob.seniorjobserver.domain.entity.UserEntity;
 import com.seniorjob.seniorjobserver.dto.LectureApplyDto;
+import com.seniorjob.seniorjobserver.repository.LectureApplyRepository;
+import com.seniorjob.seniorjobserver.repository.LectureRepository;
+import com.seniorjob.seniorjobserver.repository.UserRepository;
 import com.seniorjob.seniorjobserver.service.LectureApplyService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpSession;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/lectureapply")
 public class LectureApplyController {
 
     private final LectureApplyService lectureApplyService;
+    private final UserRepository userRepository;
+    private final LectureRepository lectureRepository;
+    private final LectureApplyRepository lectureApplyRepository;
 
     @Autowired
-    public LectureApplyController(LectureApplyService lectureApplyService) {
+    public LectureApplyController(LectureApplyService lectureApplyService, UserRepository userRepository, LectureRepository lectureRepository, LectureApplyRepository lectureApplyRepository) {
         this.lectureApplyService = lectureApplyService;
+        this.userRepository = userRepository;
+        this.lectureRepository = lectureRepository;
+        this.lectureApplyRepository = lectureApplyRepository;
     }
 
     // 강좌 참여 신청 API
-    // POST /apply/{userId}/{lectureId}/{applyReason}
-    @PostMapping("/apply")
-    public ResponseEntity<String> applyForLecture(@RequestParam Long userId, @RequestParam Long lectureId, @RequestParam(required = false) String applyReason) {
-        try {
-            lectureApplyService.applyForLecture(userId, lectureId, applyReason);
-            return ResponseEntity.ok("강좌 신청에 성공하였습니다.");
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
-        } catch (RuntimeException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
-        }
+    // POST /apply/{lectureId}
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/apply/{lectureId}")
+    public ResponseEntity<?> applyForLecture(@PathVariable Long lectureId,
+                                             @RequestParam(required = false) String applyReason,
+                                             @AuthenticationPrincipal UserDetails userDetails) {
+        UserEntity currentUser = userRepository.findByPhoneNumber(userDetails.getUsername())
+                .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없습니다."));
+
+        LectureApplyEntity appliedData = lectureApplyService.applyForLecture(currentUser.getUid(), lectureId, applyReason);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("message", currentUser.getName() + " 님" + lectureId + " 번 강좌에 참여가 완료되었습니다. 이유 : "
+                + applyReason);
+
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
     // 강좌 신청 취소 API
-    // DELETE /cancel/{userId}/{lectureId}
-    @DeleteMapping("/cancel")
-    public ResponseEntity<String> cancelLectureApply(@RequestParam Long userId, @RequestParam Long lectureId) {
+    @PreAuthorize("isAuthenticated()")
+    @DeleteMapping("/cancel/{lectureId}")
+    public ResponseEntity<?> cancelLectureApply(
+            @PathVariable Long lectureId,
+            @AuthenticationPrincipal UserDetails userDetails) {
         try {
-            String message = lectureApplyService.cancelLectureApply(userId, lectureId);
-            return ResponseEntity.ok(message);
+            UserEntity currentUser = userRepository.findByPhoneNumber(userDetails.getUsername())
+                    .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없습니다."));
+
+            LectureApplyEntity canceledData = lectureApplyService.cancelLectureApply(currentUser.getUid(), lectureId);
+
+            Map<String, Object> response = new HashMap<>();
+            response.put("message", currentUser.getName() + " 님, " + lectureId + " 번 강좌 신청이 취소되었습니다.");
+
+            return new ResponseEntity<>(response, HttpStatus.OK);
+
         } catch (RuntimeException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
     }
 
-    // 해당 강좌에 신청한 회원 목록 조회 API
+    // 해당 강좌에 신청한 회원 전체목록 조회 API
     // GET /list?lectureId=99
     @GetMapping("/list")
     public ResponseEntity<List<LectureApplyDto>> getApplicantsByLectureId(@RequestParam("lectureId") Long lectureId) {
@@ -55,32 +90,35 @@ public class LectureApplyController {
         return ResponseEntity.ok(applicants);
     }
 
-    // 회원목록에서 승인이 된 회원들을 일괄 모집마감하는 API
+    // 기존 : 회원목록에서 승인이 된 회원들을 일괄 모집마감하는 api
+    // 로그인된 회원이 개설한 강좌중 하나의 강좌를 골라 회원목록에서 승인이 된 회원들을 일괄 모집마감하는 API
     // PUT /close/{lectureId}
     @PutMapping("/close")
-    public ResponseEntity<String> closeLectureApply(@RequestParam Long lectureId) {
-        try {
-            return lectureApplyService.closeLectureApply(lectureId);
-        } catch (RuntimeException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
-        }
-    }
+    public ResponseEntity<String> closeLectureApply(
+            @RequestParam Long lectureId,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        UserEntity currentUser = userRepository.findByPhoneNumber(userDetails.getUsername())
+                .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없습니다."));
 
+        return lectureApplyService.closeLectureApply(lectureId, currentUser.getUid());
+    }
 
     // 강좌참여신청 승인 상태 개별 변경 API
     // PUT /approve/{userId}/{lectureId}/{status}
+    // 로그인된 회원이 개설한 강좌 참여신청 승인 상태 개별 변경 API로 수정 : 강좌참여신청을 한 user와 강좌를 받아 상태를 변경한다.
     @PutMapping("/approve")
     public ResponseEntity<String> updateLectureApplyStatus(
             @RequestParam Long userId,
             @RequestParam Long lectureId,
-            @RequestParam LectureApplyEntity.LectureApplyStatus status) {
+            @RequestParam LectureApplyEntity.LectureApplyStatus status,
+            @AuthenticationPrincipal UserDetails userDetails) {
         try {
-            lectureApplyService.updateLectureApplyStatus(userId, lectureId, status);
+            Long loggedInUserId = Long.valueOf(((User)userDetails).getUsername());  // userDetails에서 ID 추출
+            lectureApplyService.updateLectureApplyStatus(userId, lectureId, status, loggedInUserId);
             String message = String.format("강좌참여신청을 변경하였습니다. userId: %d, lectureId: %d", userId, lectureId);
             return ResponseEntity.ok(message);
         } catch (RuntimeException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
         }
     }
-
 }

--- a/src/main/java/com/seniorjob/seniorjobserver/repository/LectureRepository.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/repository/LectureRepository.java
@@ -16,5 +16,8 @@ public interface LectureRepository extends JpaRepository<LectureEntity, Long> {
     List<LectureEntity> findByTitleContaining(String title);
 
     Page<LectureEntity> findAll(Pageable pageable);
+
+    List<LectureEntity> findAllByUser(UserEntity user);
+
 }
 

--- a/src/main/java/com/seniorjob/seniorjobserver/service/LectureService.java
+++ b/src/main/java/com/seniorjob/seniorjobserver/service/LectureService.java
@@ -9,7 +9,6 @@ import com.seniorjob.seniorjobserver.domain.entity.LectureEntity.LectureStatus;
 import com.seniorjob.seniorjobserver.repository.UserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
@@ -124,8 +123,23 @@ public class LectureService {
     }
 
     // 세션로그인후 자신이 개설한 강좌목록 전체조회
+    public List<LectureDto> getMyLectureAll(Long userId){
+        UserEntity user = userRepository.findById(userId).orElseThrow(()-> new UsernameNotFoundException("유저를 찾을 수 없습니다."));
+        List<LectureEntity> myLectureAll = lectureRepository.findAllByUser(user);
+        return myLectureAll.stream().map(this::convertToDto).collect(Collectors.toList());
+    }
 
     // 세션로그인후 자신이 개설한 강좌 상세보기
+    public LectureDto getMyLectureDetail(Long id, Long userId) {
+        LectureEntity lectureEntity = lectureRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("강좌아이디 찾을 수 없습니다.. create_id: " + id));
+
+        if (!lectureEntity.getUser().getUid().equals(userId)) {
+            throw new RuntimeException("해당 강좌를 조회할 권한이 없습니다.");
+        }
+
+        return convertToDto(lectureEntity);
+    }
 
     // 강좌검색 : 제목
     public List<LectureDto> searchLecturesByTitle(String title) {


### PR DESCRIPTION
## **💡 Issue**

(PR | ISSUE) : #{PR | ISSUE 번호} 
feat/강좌파트세션적용_#73

## **⚡ Content**

-   작업한 내용을 적어주세요.
세션권한 적용 완료된 api
 강좌파트 : 강좌개설, 회원의 강좌수정, 회원의 강좌삭제, 세션로그인후 자신이 개설한 강좌목록 전체조회, 세션로그인후 자신이 개설한 강좌 상세보기 
 유저파트 : 유저목록, 로그아웃, 회원정보, 회원정보수정
 강좌신청파트 : 강좌참여신청, 강좌 신청 취소, 강좌일괄모집, 강좌참여신청 승인 상태 개별 변경

세센권한 적용이 필요없는 api
 강좌파트 : 강좌전체조회, 개설된 강좌 상세정보, 강좌정렬(최신순, 오래된순, 가격순, 인기순), 제목검색
 유저파트 : 회원가입, 로그인
 강좌신청파트 : 해당 강좌에 신청한 회원 전체목록 조회

## **📆 TBD**

-   작업 예정인 태스크를 적어주세요.
- 강좌제안파트 세션로그인적용, 강좌상태로직, 강좌필터링

## **🌟 Point**

-   반드시 알아야할 핵심 내용을 적어주세요.
- 꼭 로그인해주세요!

## ❓ Question

-   질문 사항이 있을 경우 적어주세요.
